### PR TITLE
Removing the console when the gui runs #1 

### DIFF
--- a/blinky.py
+++ b/blinky.py
@@ -1,3 +1,5 @@
+import ctypes
+ctypes.windll.user32.ShowWindow(ctypes.windll.kernel32.GetConsoleWindow(), 0)
 import time
 
 from PyQt5 import QtCore, QtGui, QtWidgets


### PR DESCRIPTION
Added ctypes library to call two Win32 API functions, GetConsoleWindow() and ShowWindow(), which respectively get a handle to the console window and hide it. With this modification, the console window will no longer appear when the GUI application is run.